### PR TITLE
32 bit decoding

### DIFF
--- a/src/TIFFDecoder.js
+++ b/src/TIFFDecoder.js
@@ -119,6 +119,8 @@ class TIFFDecoder extends IOBuffer {
                 pixel = fill8bit(data, stripData, pixel, length);
             } else if (bitDepth === 16) {
                 pixel = fill16bit(data, stripData, pixel, length, this.isLittleEndian());
+            } else if (bitDepth === 32) {
+                pixel = fill32bit(data, stripData, pixel, length, this.isLittleEndian());
             } else {
                 unsupported('bitDepth: ', bitDepth);
             }
@@ -149,6 +151,8 @@ function getDataArray(size, channels, bitDepth) {
         return new Uint8Array(size * channels);
     } else if (bitDepth === 16) {
         return new Uint16Array(size * channels);
+    } else if (bitDepth === 32) {
+        return new Uint32Array(size * channels);
     } else {
         unsupported('bit depth', bitDepth);
     }
@@ -164,6 +168,13 @@ function fill8bit(dataTo, dataFrom, index, length) {
 function fill16bit(dataTo, dataFrom, index, length, littleEndian) {
     for (var i = 0; i < length * 2; i += 2) {
         dataTo[index++] = dataFrom.getUint16(i, littleEndian);
+    }
+    return index;
+}
+
+function fill32bit(dataTo, dataFrom, index, length, littleEndian) {
+    for (var i = 0; i < length * 4; i += 4) {
+        dataTo[index++] = dataFrom.getUint32(i, littleEndian);
     }
     return index;
 }


### PR DESCRIPTION
not sure if this is all that is required, but it seems to work for `.decode `at least

<img width="228" alt="screen shot 2015-11-23 at 6 22 05 pm" src="https://cloud.githubusercontent.com/assets/39759/11356119/6e735798-920f-11e5-9119-faef5ae88579.png">
